### PR TITLE
Duplicate Card Filter, Drilled setState for id and outfit, added new devDependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
+    "prop-types": "^15.8.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "styled-components": "^5.3.5"

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Overview from './overview/overview.jsx';
@@ -20,6 +21,7 @@ const Loading = styled.div`
 function App() {
   const [product_id, setProduct_id] = useState(37311);
   const [loading, setLoading] = useState(0);
+  const [yourOutfits, setOutfits] = useState([]);
 
   return (
     <>
@@ -33,7 +35,9 @@ function App() {
       <Related
         product_id={product_id}
         setProduct_id={setProduct_id}
+        yourOutfits={yourOutfits}
         setLoading={setLoading}
+        setOutfits={setOutfits}
       />
       <Questions
         product_id={product_id}

--- a/src/related/productCard.jsx
+++ b/src/related/productCard.jsx
@@ -32,7 +32,7 @@ const ProductCard = function ProductCard({
   const addOutfit = (e) => {
     e.preventDefault();
     yourOutfits.push(product.id);
-    setOutfits();
+    setOutfits(yourOutfits);
   };
 
   const detailedView = (e) => {

--- a/src/related/productCard.jsx
+++ b/src/related/productCard.jsx
@@ -42,7 +42,7 @@ const ProductCard = function ProductCard({
 
   return (
     <SlimDiv>
-      <button type="button" aria-label="add to outfit" onClick={(e) => addOutfit(e)}>Some Icon goes here</button>
+      <button type="button" aria-label="add to outfit" onClick={(e) => addOutfit(e)}>Add this outfit!</button>
       <div role="button" tabIndex="0" onSubmit={(e) => detailedView(e)}>
         <div>
           <UniformImg alt={index !== undefined ? `${cards[index].style_name}, category is ${cards[index].category}` : `Sorry, no physical description is available for this item. Product category is ${product.category} and comes in the following styles: ${allStyles}`} src={(index !== undefined && cards[index].photos[0].thumbnail_url) ? cards[index].photos[0].thumbnail_url : '/assets/android-chrome-192x192.png'} />

--- a/src/related/productCard.jsx
+++ b/src/related/productCard.jsx
@@ -1,14 +1,26 @@
+/* eslint-disable react/forbid-prop-types */
 /* eslint-disable no-console */
-/* eslint-disable react/prop-types */
-/* eslint-disable react/function-component-definition */
 /* eslint-disable camelcase */
 import React, { useState, useEffect } from 'react';
+import { PropTypes } from 'prop-types';
 import styled from 'styled-components';
+
 const SlimDiv = styled.div`
   display: inline-block;
-  block-size: fit-content
+  width: 300;
+  height: 800;
+  padding: 30px
   `;
-const Productcard = ({ product = {}, cards = [], defaultIndex }) => {
+const UniformImg = styled.img`
+  max-height: 400px;
+  max-width: 200px;
+  height: auto;
+  width: auto;
+`;
+
+const ProductCard = function ProductCard({
+  product, cards, defaultIndex, yourOutfits, setProduct_id, setOutfits,
+}) {
   const [index, setIndex] = useState(defaultIndex);
   useEffect((newIndex) => {
     setIndex(newIndex || defaultIndex);
@@ -17,20 +29,50 @@ const Productcard = ({ product = {}, cards = [], defaultIndex }) => {
   const totalStyles = cards.length;
   const allStyles = cards.reduce((memo, card, i) => (i !== cards.length - 1 ? `${memo} ${card.style_name},` : `${memo} ${card.style_name}.`), '');
 
+  const addOutfit = (e) => {
+    e.preventDefault();
+    yourOutfits.push(product.id);
+    setOutfits();
+  };
+
+  const detailedView = (e) => {
+    e.preventDefault();
+    setProduct_id(product.id);
+  };
+
   return (
     <SlimDiv>
-      <div>ActionButton and image are in same div</div>
-      <img alt={index !== undefined ? `${cards[index].style_name}, category is ${cards[index].category}` : `Sorry, no physical description is available for this item. Product category is ${product.category} and comes in the following styles: ${allStyles}`} src={(index !== undefined && cards[index].photos[0].thumbnail_url) ? cards[index].photos[0].thumbnail_url : '/assets/android-chrome-192x192.png'} />
-      <br />
-      {product.name}
-      <br />
-      {product.category}
-      <br />
-      {index !== undefined ? cards[index].original_price : product.default_price}
-      <br />
-      Ratings go here
+      <button type="button" aria-label="add to outfit" onClick={(e) => addOutfit(e)}>Some Icon goes here</button>
+      <div role="button" tabIndex="0" onSubmit={(e) => detailedView(e)}>
+        <div>
+          <UniformImg alt={index !== undefined ? `${cards[index].style_name}, category is ${cards[index].category}` : `Sorry, no physical description is available for this item. Product category is ${product.category} and comes in the following styles: ${allStyles}`} src={(index !== undefined && cards[index].photos[0].thumbnail_url) ? cards[index].photos[0].thumbnail_url : '/assets/android-chrome-192x192.png'} />
+          </div>
+        <br />
+        product id: {product.id}
+        <br />
+        {product.name}
+        <br />
+        {product.category}
+        <br />
+        {index !== undefined ? cards[index].original_price : product.default_price}
+        <br />
+        Ratings go here
+      </div>
     </SlimDiv>
   );
 };
 
-export default Productcard;
+ProductCard.propTypes = {
+  product: PropTypes.object.isRequired,
+  cards: PropTypes.array.isRequired,
+  yourOutfits: PropTypes.array.isRequired,
+  setProduct_id: PropTypes.func.isRequired,
+  setOutfits: PropTypes.func.isRequired,
+  defaultIndex: PropTypes.any,
+};
+
+ProductCard.defaultProps = {
+  defaultIndex: undefined,
+};
+
+export default ProductCard;

--- a/src/related/related.jsx
+++ b/src/related/related.jsx
@@ -1,19 +1,24 @@
+/* eslint-disable react/forbid-prop-types */
 /* eslint-disable camelcase */
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { PropTypes } from 'prop-types';
 
 import ProductCard from './productCard.jsx';
 
-function Related({ product_id }) {
+function Related({
+  product_id, yourOutfits, setProduct_id, setOutfits,
+}) {
   const [products, setProducts] = useState([]);
   useEffect(() => {
     axios.get(`/products/${product_id}/related`)
       .then((res) => res.data)
       .then((relatedIds) => {
-        Promise.allSettled(relatedIds.map((id) => axios.get(`/products/${id}`)))
+        const uniqIdsList = relatedIds.filter((id, i) => relatedIds.indexOf(id) === i);
+        Promise.allSettled(uniqIdsList.map((id) => axios.get(`/products/${id}`)))
           .then((promisesArr) => promisesArr.map((res) => (res.status === 'fulfilled' ? res.value.data : {})))
           .then((productsArr) => {
-            Promise.allSettled(relatedIds.map((id) => axios.get(`/products/${id}/styles`)))
+            Promise.allSettled(uniqIdsList.map((id) => axios.get(`/products/${id}/styles`)))
               .then((promisesArr) => promisesArr.map((res) => (res.status === 'fulfilled' ? res.value.data : {})))
               .then((data) => productsArr.map((product, i) => Object.assign(data[i], product)))
               .then((finalProductArr) => setProducts(finalProductArr));
@@ -47,11 +52,19 @@ function Related({ product_id }) {
           }
         });
         return (
-          <ProductCard product={product} cards={altCards} defaultIndex={defaultIndex} key={product.id} />
+          // eslint-disable-next-line max-len
+          <ProductCard product={product} cards={altCards} defaultIndex={defaultIndex} key={product.id} setProduct_id={setProduct_id} setOutfits={setOutfits} yourOutfits={yourOutfits} />
         );
       })}
     </div>
   );
 }
+
+Related.propTypes = {
+  product_id: PropTypes.number.isRequired,
+  yourOutfits: PropTypes.array.isRequired,
+  setProduct_id: PropTypes.func.isRequired,
+  setOutfits: PropTypes.func.isRequired,
+};
 
 export default Related;


### PR DESCRIPTION
Duplicate Filter: https://trello.com/c/IXz32OKW
Click functionality: https://trello.com/c/pYnkKcI2
Related
-Ids from api were coming back duplicated, so I filtered them out to avoid seeing duplicate product on the page
App
-I set up an outfits array at top-most state that will deliver them to an Outfit component in the future
-setState function for productID and outfits being drilled into Related and subcomponents for implementation
Package.json
-devDependency - added 'prop-types' so as to meet reqs by ABnB for props statement at the bottom of the file for React components (there is an example on line 63 of related)

Apparently cant break into smaller merge requests - sorry to whoever has to read this, will try harder to make these smaller
ProductCards
-receiving setState funcs via props
-added functionality to the add outfit button - now updates outfit array in app by pushing product id
-card updates product id in app on click
        -navigates to a new page displaying clicked product as the main product